### PR TITLE
animation timing set to 200ms instead of 300ms

### DIFF
--- a/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.ts
@@ -17,7 +17,7 @@ import { CONSTANT } from './../constants';
       transition(':leave', [
         style({ height: '*', opacity: 0.2 }),
         group([
-          animate(300, style({ height: 0 })),
+          animate(200, style({ height: 0 })),
           animate('200ms ease-out', style({ opacity: 0 }))
         ])
       ]),
@@ -34,10 +34,10 @@ import { CONSTANT } from './../constants';
       state('yes', style({ transform: 'rotate(0deg)', })),
 
       transition('no => yes',
-        animate(300)
+        animate(200)
       ),
       transition('yes => no',
-        animate(300)
+        animate(200)
       )
     ]),
     trigger('isExpandedRTL', [
@@ -45,10 +45,10 @@ import { CONSTANT } from './../constants';
       state('yes', style({ transform: 'rotate(0deg)', })),
 
       transition('no => yes',
-        animate(300)
+        animate(200)
       ),
       transition('yes => no',
-        animate(300)
+        animate(200)
       )
     ])
   ]


### PR DESCRIPTION
lowering animation rate will make it look a lot smoother when expanding menus,
the animation of the chevron icon and the expanding will be in sync.