### PR TITLE
fix: remove peer dependency warning

### DIFF
--- a/projects/ng-material-multilevel-menu/package.json
+++ b/projects/ng-material-multilevel-menu/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/ShankyTiwari/ng-material-multilevel-menu/issues"
   },
   "peerDependencies": {
-    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
+    "@angular/common": ">= 6.0.0-rc.0 || >= 6.0.0",
+    "@angular/core": ">= 6.0.0-rc.0 || >= 6.0.0"
   }
 }


### PR DESCRIPTION
Been using the package for a short while with Angular 7 and I can't find any issues with it except the warnings rendered.

```
warning " > ng-material-multilevel-menu@4.9.2" has incorrect peer dependency "@angular/common@^6.0.0-rc.0 || ^6.0.0".
warning " > ng-material-multilevel-menu@4.9.2" has incorrect peer dependency "@angular/core@^6.0.0-rc.0 || ^6.0.0".
```

Updated the package.json to remove the warnings

re #45