### PR TITLE
fixed keyboard_down_arrow animation on RTL  (edge and ie).

### DIFF
--- a/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.css
+++ b/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.css
@@ -28,7 +28,11 @@
   width: 22px;
   height: 22px;
 }
-
+.amml-icon-arrow-container {
+  direction: ltr;
+  display: flex;
+  align-items: center;
+}
 div[dir="ltr"] .amml-icon {
   margin-right: 16px;
 }

--- a/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.html
+++ b/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.html
@@ -7,21 +7,21 @@
       </span>
       <mat-icon *ngSwitchCase="'icon'" class="amml-icon">
         {{node.icon}}
-      </mat-icon>      
+      </mat-icon>
       <mat-icon *ngSwitchCase="'svgicon'" svgIcon="{{node.svgIcon}}" class="amml-icon amml-svg-icon">
       </mat-icon>
       <img matListAvatar *ngSwitchCase="'imageicon'" class="amml-icon" src="{{node.imageIcon}}" alt="{{node.label}}"/>
-    </div>    
+    </div>
     <span class="label">{{node.label}}</span>
   </div>
-  <ng-container *ngIf='hasItems()'>
-    <mat-icon *ngIf='!isRtlLayout()' [@isExpandedLTR]="hasItems() && expanded ? 'yes' : 'no'">
+  <div class="amml-icon-arrow-container" *ngIf='hasItems()'>
+    <mat-icon *ngIf='!isRtlLayout()' [@isExpandedLTR]="expanded ? 'yes' : 'no'">
       keyboard_arrow_down
     </mat-icon>
-    <mat-icon *ngIf='isRtlLayout()'  [@isExpandedRTL]="hasItems() && expanded ? 'yes' : 'no'">
+    <mat-icon *ngIf='isRtlLayout()'  [@isExpandedRTL]="expanded ? 'yes' : 'no'">
       keyboard_arrow_down
     </mat-icon>
-  </ng-container>
+  </div>
 </mat-list-item>
 
 <mat-divider></mat-divider>


### PR DESCRIPTION
bypasses an issue with the keyboard down arrow icon animation, when using RTL mode, in IE (on chrome all worked well), by adding a container to the element and forcing LTR direction for it.

this is actually caused because of a larger issue with mat-icon as shown in this example:
[stackblitz example](https://stackblitz.com/edit/angular-xnhqbw-5zr2oq?file=app/menu-overview-example.css)

![example of transform:rotate isnt working as expected in IE and EDGE vs chrome ](https://user-images.githubusercontent.com/6926633/57212553-c172c500-6fec-11e9-9240-94db8bc0ca81.png)


