### PR TITLE
Default font awesome icon class to "fas"

### DIFF
--- a/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.ts
@@ -84,6 +84,13 @@ export class ListItemComponent implements OnChanges, OnInit {
   }
   ngOnInit() {
     this.selectedListClasses[CONSTANT.DISABLED_ITEM_CLASS_NAME] = this.node.disabled;
+
+    if (this.node.faIcon !== null &&
+      this.node.faIcon !== undefined &&
+      this.node.faIcon.match(/\bfa\w(?!-)/) === null) {
+      this.node.faIcon = `fas ${this.node.faIcon}`;
+    }
+
     this.selectedListClasses[`level-${this.level}-submenulevel-${this.submenuLevel}`] = true;
     if (typeof this.node.expanded === 'boolean') {
       this.expanded = this.node.expanded;


### PR DESCRIPTION
Removes the need for the user to specify a prefix class in faIcon
For example:
```js
{
    label: 'Item 1.2.2',
    faIcon: 'fas fa-ambulance',
    ...
}
```
can now be written as
```js
{
    label: 'Item 1.2.2',
    faIcon: 'fa-ambulance',
    ...
}
```
in which case the class will be set to `fas fa-ambulance`.

User can still specify a Font Awesome class prefix such as `far`, `fab`. However, class `fa` will be changed to the default `fas`, as it has been deprecated in Font Awesome v5.
