### PR TITLE
added a keyvalue ordering function to fix ordering issue

### DIFF
--- a/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.html
+++ b/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.html
@@ -28,7 +28,7 @@
 <mat-divider></mat-divider>
 
 <div *ngIf="hasItems() && expanded" [@slideInOut] [dir]="isRtlLayout() ? 'rtl' : 'ltr'" [ngClass]="classes">
-  <ng-list-item *ngFor="let singleNode of nodeChildren | keyvalue : multilevelMenuService.kvDummyIComparerFn"
+  <ng-list-item *ngFor="let singleNode of nodeChildren | keyvalue : multilevelMenuService.kvDummyComparerFn"
     [nodeConfiguration]='nodeConfiguration'
     [node]="singleNode.value"
     [level]="level + 1"

--- a/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.html
+++ b/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.html
@@ -28,7 +28,7 @@
 <mat-divider></mat-divider>
 
 <div *ngIf="hasItems() && expanded" [@slideInOut] [dir]="isRtlLayout() ? 'rtl' : 'ltr'" [ngClass]="classes">
-  <ng-list-item *ngFor="let singleNode of nodeChildren | keyvalue"
+  <ng-list-item *ngFor="let singleNode of nodeChildren | keyvalue : multilevelMenuService.kvDummyIComparerFn"
     [nodeConfiguration]='nodeConfiguration'
     [node]="singleNode.value"
     [level]="level + 1"

--- a/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/list-item/list-item.component.ts
@@ -1,11 +1,11 @@
-import { Component, OnInit, OnChanges, Input, Output, EventEmitter } from '@angular/core';
+import { animate, group, state, style, transition, trigger } from '@angular/animations';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
 import { Router } from '@angular/router';
-import { trigger, style, transition, animate, state, group } from '@angular/animations';
-
+import { Configuration, ListStyle, MultilevelNodes } from './../app.model';
+import { CONSTANT } from './../constants';
 import { MultilevelMenuService } from './../multilevel-menu.service';
 
-import { Configuration, MultilevelNodes, ListStyle } from './../app.model';
-import { CONSTANT } from './../constants';
+
 
 @Component({
   selector: 'ng-list-item',
@@ -68,7 +68,7 @@ export class ListItemComponent implements OnChanges, OnInit {
   firstInitializer = false;
   constructor(
     private router: Router,
-    private multilevelMenuService: MultilevelMenuService
+    public multilevelMenuService: MultilevelMenuService
   ) {
     this.selectedListClasses = {
       [CONSTANT.DEFAULT_LIST_CLASS_NAME]: true,

--- a/projects/ng-material-multilevel-menu/src/lib/multilevel-menu.service.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/multilevel-menu.service.ts
@@ -53,9 +53,9 @@ export class MultilevelMenuService {
     this.recursiveCheckLink(node, link);
     return this.foundLinkObject;
   }
-  // overrides key-value pipe's default reordering (by key) by implementing dummy icomprare
+  // overrides key-value pipe's default reordering (by key) by implementing dummy comprarer function
   // https://angular.io/api/common/KeyValuePipe#description
-  kvDummyIComparerFn() {
+  kvDummyComparerFn() {
     return 0;
   }
 }

--- a/projects/ng-material-multilevel-menu/src/lib/multilevel-menu.service.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/multilevel-menu.service.ts
@@ -53,4 +53,9 @@ export class MultilevelMenuService {
     this.recursiveCheckLink(node, link);
     return this.foundLinkObject;
   }
+  // overrides key-value pipe's default reordering (by key) by implementing dummy icomprare
+  // https://angular.io/api/common/KeyValuePipe#description
+  kvDummyIComparerFn() {
+    return 0;
+  }
 }

--- a/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.html
+++ b/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.html
@@ -1,7 +1,7 @@
 <div [ngClass]="getClassName()" [ngStyle]="getGlobalStyle()" *ngIf='items.length !== 0' [dir]="isRtlLayout() ? 'rtl' : 'ltr'">
   <mat-list>
     <ng-list-item
-      *ngFor="let node of items | keyvalue: multilevelMenuService.kvDummyIComparerFn"
+      *ngFor="let node of items | keyvalue: multilevelMenuService.kvDummyComparerFn"
       [nodeConfiguration]='nodeConfig'
       [node]='node.value'
       [level]="1"

--- a/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.html
+++ b/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.html
@@ -1,7 +1,7 @@
 <div [ngClass]="getClassName()" [ngStyle]="getGlobalStyle()" *ngIf='items.length !== 0' [dir]="isRtlLayout() ? 'rtl' : 'ltr'">
   <mat-list>
     <ng-list-item
-      *ngFor="let node of items | keyvalue"
+      *ngFor="let node of items | keyvalue: multilevelMenuService.kvDummyIComparerFn"
       [nodeConfiguration]='nodeConfig'
       [node]='node.value'
       [level]="1"

--- a/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.ts
@@ -1,10 +1,10 @@
-import { Component, OnInit, OnChanges, Input, Output, EventEmitter } from '@angular/core';
-import { Router, NavigationEnd } from '@angular/router';
-
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { BackgroundStyle, Configuration, MultilevelNodes } from './app.model';
+import { CONSTANT } from './constants';
 import { MultilevelMenuService } from './multilevel-menu.service';
 
-import { Configuration, MultilevelNodes, BackgroundStyle } from './app.model';
-import { CONSTANT } from './constants';
+
 
 @Component({
   selector: 'ng-material-multilevel-menu',
@@ -30,7 +30,7 @@ export class NgMaterialMultilevelMenuComponent implements OnInit, OnChanges {
   isInvalidConfig = true;
   constructor(
     private router: Router,
-    private multilevelMenuService: MultilevelMenuService
+    public multilevelMenuService: MultilevelMenuService
   ) { }
   ngOnChanges() {
     this.detectInvalidConfig();


### PR DESCRIPTION
key value default ordering is by key.

by adding a dummy comparer function, and passing it as a parameter to the keyvalue pipes, we basically ignore that ordering and use the original object's one.

fixes #69 