### PR TITLE
feat: Add isMenuReady() event for menu component

### DIFF
--- a/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.ts
@@ -15,6 +15,7 @@ export class NgMaterialMultilevelMenuComponent implements OnInit, OnChanges, OnD
   @Input() configuration: Configuration = null;
   @Output() selectedItem = new EventEmitter<MultilevelNodes>();
   @Output() selectedLabel = new EventEmitter<MultilevelNodes>();
+  @Output() menuIsReady = new EventEmitter<MultilevelNodes[]>();
   @ContentChild('listTemplate', {static: true}) listTemplate: TemplateRef<ElementRef>;
 
   expandCollapseStatusSubscription: Subscription = null;
@@ -81,6 +82,7 @@ export class NgMaterialMultilevelMenuComponent implements OnInit, OnChanges, OnD
       this.items = this.items.filter(n => !n.hidden);
       this.multilevelMenuService.addRandomId(this.items);
       this.isInvalidData = false;
+      this.menuIsReady.emit(this.items);
     }
   }
   detectInvalidConfig(): void {


### PR DESCRIPTION
Previously, when menu items were changed after component initialization, it was not possible to
easily know when IDs are assigned to these items. This commit trigger an event isMenuReady() after data are validated and IDs are assigned.
