### PR TITLE
feat: Add isMenuReady() event for menu component

### DIFF
--- a/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.ts
@@ -46,6 +46,9 @@ export class NgMaterialMultilevelMenuComponent implements OnInit, OnChanges, OnD
     this.detectInvalidConfig();
     this.initExpandCollapseStatus();
     this.initSelectedMenuID();
+    if (!this.isInvalidData) {
+      this.menuIsReady.emit(this.items);
+    }
   }
   ngOnInit() {
     if (
@@ -82,7 +85,6 @@ export class NgMaterialMultilevelMenuComponent implements OnInit, OnChanges, OnD
       this.items = this.items.filter(n => !n.hidden);
       this.multilevelMenuService.addRandomId(this.items);
       this.isInvalidData = false;
-      this.menuIsReady.emit(this.items);
     }
   }
   detectInvalidConfig(): void {

--- a/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.ts
+++ b/projects/ng-material-multilevel-menu/src/lib/ng-material-multilevel-menu.component.ts
@@ -15,6 +15,7 @@ export class NgMaterialMultilevelMenuComponent implements OnInit, OnChanges, OnD
   @Input() configuration: Configuration = null;
   @Output() selectedItem = new EventEmitter<MultilevelNodes>();
   @Output() selectedLabel = new EventEmitter<MultilevelNodes>();
+  @Output() menuIsReady = new EventEmitter<MultilevelNodes[]>();
   @ContentChild('listTemplate', {static: true}) listTemplate: TemplateRef<ElementRef>;
 
   expandCollapseStatusSubscription: Subscription = null;
@@ -81,6 +82,7 @@ export class NgMaterialMultilevelMenuComponent implements OnInit, OnChanges, OnD
       this.items = this.items.filter(n => !n.hidden);
       this.multilevelMenuService.addRandomId(this.items);
       this.isInvalidData = false;
+      this.menuIsReady.emit(this.items);
     }
   }
   detectInvalidConfig(): void {


### PR DESCRIPTION
The patch works as expected and it is possible to select a menu item by ID.

However, it makes sense to do an additional commit that fixes the situation in a bit more complex way. Adding subscription on selectedMenuItem$ in the onChange() method is potentially dangerous. Because subscription can be done multiple times (what does have purpose here) and unsubscription is done only on the last one. If the subscription is done in onInit() or constructor() then the emitter could be used as in the first patch. But I expected there could be other problems when someone will do multiple changes on the menu. Current situation works fine for static menu item definitions and transition from empty to defined. I do not expect that there will be many users of more complex scenario as no issues are reported. 